### PR TITLE
Tui: Prune temp vars and improper ex-handling.

### DIFF
--- a/bin/run_tui.js
+++ b/bin/run_tui.js
@@ -3,26 +3,20 @@ const os = require('os');
 const Redis = require('redis');
 const IPFSDaemonFactory = require('ipfsd-ctl');
 const { PublicFileManager } = require('../index');
-const tui = require('../lib/tui/tui');
+const tui = require('../tui/tui');
 
-(async()=>{
-  //this is for dynamic spawning of a ipfs daemon
-  const ipfsFactory = IPFSDaemonFactory.create();
-  const homedir = os.homedir();
-  let init;
-  //if the ipfs init file exists, don't init the daemon and visa versa
-  try {
-   fs.statSync(`${homedir}/.ipfs`);
-   init = false;
-  } catch (error) {
-    init = true;
-  }
-  //spawn a non-disposable(deterministic key generation from init file) daemon
-  const ipfsd = await ipfsFactory.spawn({init: init, disposable: false , start: true});
-  ipfs = ipfsd.api;
-  const redis = Redis.createClient({host: 'sprightly-redwood-7a63d23fa9.redisgreen.net', port:11042, password: 'a4f74e5842c24c8db40013fc20ab8200'});
-
-  const PFM = await new PublicFileManager(ipfs,redis);
-
-  tui(PFM);
+(async () => {
+  // Spawn a non-disposable (deterministic key generation from init
+  // file) daemon.
+  const ipfsDaemon = await IPFSDaemonFactory.create().spawn({
+    init: !fs.existsSync(`${os.homedir()}/.ipfs`),
+    disposable: false,
+    start: true
+  });
+  const redisClient = Redis.createClient({
+    host: 'sprightly-redwood-7a63d23fa9.redisgreen.net',
+    port:11042,
+    password: 'a4f74e5842c24c8db40013fc20ab8200'
+  })
+  tui(await new PublicFileManager(ipfsDaemon.api, redisClient));
 })();


### PR DESCRIPTION
Using fs.statSync and exception handling to perform a boolean
condition is verbose.

Replace with existsSync, which returns a boolean.

Remove a few temporary variables that didn't add much clarity to the procedures
necessary for preparing the tui to launch.