### PR TITLE
Repertory: Provide search index.

### DIFF
--- a/__tests__/repertory.test.js
+++ b/__tests__/repertory.test.js
@@ -1,0 +1,25 @@
+const Repertory = require('../lib/repertory')
+
+test('The repertory exists', () => {
+  const m = new Repertory()
+})
+
+test('The repertory represents a searchable catalog of information', () => {
+  const m = new Repertory({})
+  expect(m).toHaveProperty('index')
+})
+
+test('Registering a thing stores its information in the index', () => {
+  const m = new Repertory({})
+  m.register(fake_thing())
+  expect(m.index[fake_thing().information()]).toEqual(fake_thing().uri())
+})
+
+test('Querying the repertory with existing information returns a uri', () => {
+  const m = new Repertory({'fake': 0})
+  expect(m.query('fake')).toEqual(0)
+})
+
+function fake_thing() {
+  return { information: function() { return 'fake'} , uri: function() { return 0 } }
+}

--- a/lib/repertory.js
+++ b/lib/repertory.js
@@ -1,0 +1,25 @@
+// Repertory. A searchable catalog of information, like Otlet's Repertoire
+// Bibliographique Universel (RBU).
+
+class Repertory {
+
+  constructor(index = {}) {
+    this._index = index
+  }
+
+  get index() {
+    return this._index
+  }
+
+  register(thing) {
+    if (this._index[thing.information()]) return
+    this._index[thing.information()] = thing.uri()
+  }
+
+  query(information) {
+    return this.index[information]
+  }
+
+}
+
+module.exports = Repertory


### PR DESCRIPTION
The system needs a way to 'find information', thereby returning the uri
of a Thing that represents that information. It is essentially a search
index or catalog.

In history, the Mundaneum's massive 'card catalog' was named by Otlet as
the Repertoire Bibliographique Universel (RBU) or 'Universal Bibliographic
Repertory.'