### PR TITLE
Rhizome: Introduce API; Thing: separate tagging directions

### DIFF
--- a/__tests__/repertory.test.js
+++ b/__tests__/repertory.test.js
@@ -12,7 +12,7 @@ test('The repertory represents a searchable catalog of information', () => {
 test('Registering a thing stores its information in the index', () => {
   const m = new Repertory({})
   m.register(fake_thing())
-  expect(m.index[fake_thing().information()]).toEqual(fake_thing().uri())
+  expect(m.index[fake_thing().information]).toEqual(fake_thing().uri)
 })
 
 test('Seeking the repertory with existing information returns a uri if found', () => {
@@ -21,5 +21,5 @@ test('Seeking the repertory with existing information returns a uri if found', (
 })
 
 function fake_thing() {
-  return { information: function() { return 'fake'} , uri: function() { return 0 } }
+  return { information: 'fake' , uri: 0 }
 }

--- a/__tests__/repertory.test.js
+++ b/__tests__/repertory.test.js
@@ -15,9 +15,9 @@ test('Registering a thing stores its information in the index', () => {
   expect(m.index[fake_thing().information()]).toEqual(fake_thing().uri())
 })
 
-test('Querying the repertory with existing information returns a uri', () => {
+test('Seeking the repertory with existing information returns a uri if found', () => {
   const m = new Repertory({'fake': 0})
-  expect(m.query('fake')).toEqual(0)
+  expect(m.seek('fake')).toEqual(0)
 })
 
 function fake_thing() {

--- a/__tests__/rhizome.test.js
+++ b/__tests__/rhizome.test.js
@@ -4,3 +4,44 @@ test('The rhizome exists', () => {
   const r = new Rhizome()
 })
 
+test('Storing new information in the rhizome creates a thing', () => {
+  const r = new Rhizome()
+  information = 'fake'
+  thing = r.store(information)
+  expect(thing.information).toBe(information)
+  expect(thing).toHaveProperty('uri')
+})
+
+test('Storing in the rhizome has side effects of storing in the continuum and registering in the repertory', () => {
+  const fakeContinuum = { store: jest.fn(), retrieve: jest.fn() }
+  const fakeRepertory = { register: jest.fn(), seek: jest.fn() }
+  const r = new Rhizome(fakeContinuum, fakeRepertory)
+  r.store('fake')
+  expect(fakeContinuum.store).toHaveBeenCalled()
+  expect(fakeRepertory.register).toHaveBeenCalled()
+})
+
+test('Attempting to store existing information in the rhizome does not create a new thing', () => {
+  const r = new Rhizome()
+  thing = r.store('fake')
+  identical_thing = r.store(thing.information)
+  expect(identical_thing.uri).toBe(thing.uri)
+})
+
+test('Information stored in the rhizome makes it retrievable as a thing by a uri', () => {
+  const r = new Rhizome()
+  thing = r.store('fake')
+  expect(thing).toBe(r.retrieve(thing.uri))
+})
+
+test('Things stored in the rhizome are seekable by their information', () => {
+  const r = new Rhizome()
+  thing = r.store('fake')
+  expect(thing.uri).toBe(r.seek(thing.information).uri)
+})
+
+test('Seeking something not stored in the rhizome returns undefined', () => {
+  const r = new Rhizome()
+  expect(r.seek('fake')).toBe(undefined)
+})
+

--- a/__tests__/rhizome.test.js
+++ b/__tests__/rhizome.test.js
@@ -1,3 +1,6 @@
-test('TODO', () => {
+const Rhizome = require('../lib/rhizome_new')
 
+test('The rhizome exists', () => {
+  const r = new Rhizome()
 })
+

--- a/__tests__/thing.test.js
+++ b/__tests__/thing.test.js
@@ -16,13 +16,27 @@ test('A Thing has a URI', () => {
 
 test('A Thing has a tags', () => {
   const thing = new Thing()
-  expect(thing).toHaveProperty('uri')
+  expect(thing).toHaveProperty('tags')
 })
 
-test('Tagging one Thing with another adds their URIs to both their tags lists', () => {
-  thing = new Thing('fake', 0, [])
-  other = new Thing('other fake', 1, [])
-  thing.tag(other)
-  expect(thing.tags).toContain(other.uri)
-  expect(other.tags).toContain(thing.uri)
+test('A Thing has targets', () => {
+  const thing = new Thing()
+  expect(thing).toHaveProperty('targets')
 })
+
+test("Tagging Thing A with Thing B adds B's uri to A's tag list, and A's uri to B's targets list", () => {
+  a = new Thing('A', 0, [])
+  b = new Thing('B', 1, [])
+  a.tag_with(b)
+  expect(a.tags).toContain(b.uri)
+  expect(b.targets).toContain(a.uri)
+})
+
+test("Telling Thing A to tag Thing B adds A's uri to B's tags list, and B's uri to A's targets list", () => {
+  a = new Thing('A', 0, [])
+  b = new Thing('B', 1, [])
+  a.tag(b)
+  expect(b.tags).toContain(a.uri)
+  expect(a.targets).toContain(b.uri)
+})
+

--- a/lib/repertory.js
+++ b/lib/repertory.js
@@ -12,8 +12,8 @@ class Repertory {
   }
 
   register(thing) {
-    if (this._index[thing.information()]) return
-    this._index[thing.information()] = thing.uri()
+    if (this._index[thing.information]) return
+    this._index[thing.information] = thing.uri
   }
 
   seek(information) {

--- a/lib/repertory.js
+++ b/lib/repertory.js
@@ -16,7 +16,7 @@ class Repertory {
     this._index[thing.information()] = thing.uri()
   }
 
-  query(information) {
+  seek(information) {
     return this.index[information]
   }
 

--- a/lib/rhizome_new.js
+++ b/lib/rhizome_new.js
@@ -1,0 +1,7 @@
+// Rhizome. A living distribution of all the world's information.
+
+class Rhizome {
+
+}
+
+module.exports = Rhizome

--- a/lib/rhizome_new.js
+++ b/lib/rhizome_new.js
@@ -1,6 +1,29 @@
 // Rhizome. A living distribution of all the world's information.
 
+const Continuum = require('./continuum')
+const Repertory = require('./repertory')
+
 class Rhizome {
+
+  constructor(continuum = new Continuum(), repertory = new Repertory()) {
+    this._continuum = continuum
+    this._repertory = repertory
+  }
+
+  store(information) {
+    if (this.seek(information) != undefined) return this.seek(information)
+    var thing = this._continuum.store(information)
+    this._repertory.register(thing)
+    return thing
+  }
+
+  retrieve(uri) {
+    return this._continuum.retrieve(uri)
+  }
+
+  seek(information) {
+    return this.retrieve(this._repertory.seek(information))
+  }
 
 }
 

--- a/lib/thing.js
+++ b/lib/thing.js
@@ -2,10 +2,11 @@
 
 class Thing {
 
-  constructor(information, uri, tags = []) {
+  constructor(information, uri, tags = [], targets = []) {
     this._information = information
     this._uri = uri
     this._tags = tags
+    this._targets = targets
   }
 
   get information() {
@@ -20,14 +21,28 @@ class Thing {
     return this._tags
   }
 
-  tag(other) {
-    if (this.isTagged(other)) return;
+  get targets() {
+    return this._targets
+  }
+
+  tag_with(other) {
+    if (this.isTaggedBy(other)) return;
     this.tags.push(other.uri)
     other.tag(this)
   }
 
-  isTagged(other) {
+  tag(target) {
+    if (this.isTagging(target)) return;
+    this.targets.push(target.uri)
+    target.tag_with(this)
+  }
+
+  isTaggedBy(other) {
     return this.tags.includes(other.uri)
+  }
+
+  isTagging(target) {
+    return this.targets.includes(target.uri)
   }
 
 }


### PR DESCRIPTION
This PR introduces the highest-level API for Rhizome. It defines the API expectations of its dependencies: Continuum and Repertory.

This outer API is public, and is not intended to change unless absolutely necessary.

[Another commit](https://github.com/scmilee/rhizome/commit/4353e10dc44cc4c129d7d79632b55d4fedf3dc48) in this PR revises the way tags work on Things. Direction is important. See [the commit message](https://github.com/scmilee/rhizome/commit/4353e10dc44cc4c129d7d79632b55d4fedf3dc48) for more details.
